### PR TITLE
Feat : 가입 대기 스페이스 목록 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-label": "^2.1.0",
+        "@radix-ui/react-popover": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.2",
         "@tanstack/react-query": "^5.51.9",
@@ -3506,6 +3507,128 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.2.tgz",
+      "integrity": "sha512-u2HRUyWW+lOiA2g0Le0tMmT55FGOEWHwPFt1EPfbLly7uXQExFo5duNKqG2DzmFXIdqOeNd+TpE8baHWJCyP9w==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz",
+      "integrity": "sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.2.tgz",
+      "integrity": "sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
+      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.51.9",

--- a/src/assets/icons/close-icon.svg
+++ b/src/assets/icons/close-icon.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 4L4 12M12 12L4 4.00001" stroke="white" stroke-width="1.67" stroke-linecap="round"/>
+<path d="M12 4L4 12M12 12L4 4.00001" stroke="currentColor" stroke-width="1.67" stroke-linecap="round"/>
 </svg>

--- a/src/components/common/modal/alert-modal/alert-modal.stories.tsx
+++ b/src/components/common/modal/alert-modal/alert-modal.stories.tsx
@@ -1,0 +1,34 @@
+import { AlertModal } from '@/components/common/modal/alert-modal/alert-modal';
+import { Meta, StoryFn } from '@storybook/react';
+
+export default {
+  title: 'components/common/modal/AlertModal',
+  component: AlertModal,
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    description: {
+      control: 'text',
+    },
+    confirmButtonBgColor: {
+      control: 'select',
+      options: ['red', 'black'],
+    },
+    onConfirm: { action: 'clicked' },
+    onClose: { action: 'closed' },
+  },
+} as Meta;
+
+const Template: StoryFn<React.ComponentProps<typeof AlertModal>> = (args) => (
+  <AlertModal {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  title: '로그인이 필요한 서비스 입니다.',
+  description: '확인을 누르면 로그인 화면으로 이동합니다.',
+  confirmButtonBgColor: 'red',
+  onConfirm: () => alert('onClick!'),
+  onClose: () => alert('onClose!'),
+};

--- a/src/components/common/modal/alert-modal/alert-modal.tsx
+++ b/src/components/common/modal/alert-modal/alert-modal.tsx
@@ -13,6 +13,7 @@ import tw from 'twin.macro';
 export type TAlertModalProps = {
   title: string;
   description: string;
+  confirmButtonBgColor?: 'red' | 'black';
   onConfirm: () => void;
   onClose?: () => void;
 };
@@ -20,6 +21,7 @@ export type TAlertModalProps = {
 export const AlertModal = ({
   title,
   description,
+  confirmButtonBgColor = 'red',
   onConfirm,
   onClose,
 }: TAlertModalProps) => {
@@ -37,7 +39,7 @@ export const AlertModal = ({
         </ModalHeader>
         <DialogFooter>
           <Button
-            bgColor="red"
+            bgColor={confirmButtonBgColor}
             onClick={() => {
               onConfirm();
               onClose && onClose();

--- a/src/components/common/modal/alert-modal/alert-modal.tsx
+++ b/src/components/common/modal/alert-modal/alert-modal.tsx
@@ -7,8 +7,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '../../button/button';
-import styled from 'styled-components';
-import tw from 'twin.macro';
+import tw, { styled } from 'twin.macro';
 
 export type TAlertModalProps = {
   title: string;

--- a/src/components/common/modal/confirm-modal/confirm-modal.stories.tsx
+++ b/src/components/common/modal/confirm-modal/confirm-modal.stories.tsx
@@ -1,0 +1,34 @@
+import { ConfirmModal } from '@/components/common/modal/confirm-modal/confirm-modal';
+import { Meta, StoryFn } from '@storybook/react';
+
+export default {
+  title: 'components/common/modal/ConfirmModal',
+  component: ConfirmModal,
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    description: {
+      control: 'text',
+    },
+    confirmButtonBgColor: {
+      control: 'select',
+      options: ['red', 'black'],
+    },
+    onConfirm: { action: 'clicked' },
+    onClose: { action: 'closed' },
+  },
+} as Meta;
+
+const Template: StoryFn<React.ComponentProps<typeof ConfirmModal>> = (args) => (
+  <ConfirmModal {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  title: '스페이스 참여 요청',
+  description: '스페이스에 참여 요청을 보내시겠습니까?',
+  confirmButtonBgColor: 'black',
+  onConfirm: () => alert('onClick!'),
+  onClose: () => alert('onClose!'),
+};

--- a/src/components/common/modal/confirm-modal/confirm-modal.tsx
+++ b/src/components/common/modal/confirm-modal/confirm-modal.tsx
@@ -8,8 +8,7 @@ import {
   DialogClose,
 } from '@/components/ui/dialog';
 import { Button } from '../../button/button';
-import styled from 'styled-components';
-import tw from 'twin.macro';
+import tw, { styled } from 'twin.macro';
 
 export type TConfirmModalProps = {
   title: string;

--- a/src/components/common/tooltip/tooltip.stories.tsx
+++ b/src/components/common/tooltip/tooltip.stories.tsx
@@ -28,6 +28,7 @@ export default {
     sideOffset: {
       control: 'number',
     },
+    onTooltipClick: { action: 'clicked' },
   },
 } as Meta;
 
@@ -45,4 +46,5 @@ Default.args = {
   tooltipLocation: 'top',
   delayDuration: 300,
   sideOffset: 10,
+  onTooltipClick: () => alert('clicked'),
 };

--- a/src/components/image-input/image-input.tsx
+++ b/src/components/image-input/image-input.tsx
@@ -55,7 +55,7 @@ export const ImageInput = forwardRef<
         <div className="relative">
           <ImagePreivew src={previewSrc} alt="preview" />
           <CloseIcon
-            className="bg-black rounded-xl cursor-pointer absolute top-1 right-1"
+            className="bg-black rounded-xl cursor-pointer absolute top-1 right-1 text-pureWhite"
             onClick={handleFileRemove}
           />
         </div>

--- a/src/components/modal/create-space-modal/create-space-modal.tsx
+++ b/src/components/modal/create-space-modal/create-space-modal.tsx
@@ -6,8 +6,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '../../common/button/button';
-import styled from 'styled-components';
-import tw from 'twin.macro';
+import tw, { styled } from 'twin.macro';
 import {
   Form,
   FormControl,

--- a/src/components/modal/user-setting-modal/user-setting-modal.tsx
+++ b/src/components/modal/user-setting-modal/user-setting-modal.tsx
@@ -7,8 +7,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '../../common/button/button';
-import styled from 'styled-components';
-import tw from 'twin.macro';
+import tw, { styled } from 'twin.macro';
 import {
   Form,
   FormControl,

--- a/src/components/space-list/waiting-space-list.tsx
+++ b/src/components/space-list/waiting-space-list.tsx
@@ -1,0 +1,87 @@
+import tw, { styled } from 'twin.macro';
+import FileIcon from '@/assets/icons/file.svg?react';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover';
+import CloseIcon from '@/assets/icons/close-icon.svg?react';
+import DefulatSpaceProfile from '@/assets/icons/default-space-profile.svg';
+import { Button } from '../common/button/button';
+import { useState } from 'react';
+import { useGetWaitingSpaceList } from '@/hooks/queries/use-get-waiting-space-list';
+
+// 참여취소 api 추가 필요
+export const WaitingSpaceList: React.FC<{ containerWidth: number }> = ({
+  containerWidth,
+}) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const { data: spaceData = [] } = useGetWaitingSpaceList();
+
+  return (
+    <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+      <PopoverTrigger asChild>
+        <WaitingSpaceDropdownButton>
+          <FileIcon className="size-7 md:size-6" />
+          <WaitingSpaceCountWrapper>
+            <WaitingSpaceCount>{spaceData.length}</WaitingSpaceCount>
+          </WaitingSpaceCountWrapper>
+        </WaitingSpaceDropdownButton>
+      </PopoverTrigger>
+      <StyledPopoverContent
+        style={{ width: `${containerWidth}px` }}
+        align="end"
+        sideOffset={0}
+      >
+        <WaitingSpaceWrapper>
+          <WaitingSpaceListHeader>
+            <WaitingSpaceListTitle>가입 대기 목록</WaitingSpaceListTitle>
+            <CloseIcon
+              className="size-5 md:size-4 cursor-pointer"
+              onClick={() => {
+                setIsPopoverOpen(false);
+              }}
+            />
+          </WaitingSpaceListHeader>
+          <SpaceList>
+            {spaceData.map((space) => (
+              <SpaceListItem key={space.id}>
+                <SpaceContentWrapper>
+                  <ImageTitleWrapper>
+                    <SpaceImage
+                      src={space.image ? space.image : DefulatSpaceProfile}
+                      alt="space profile"
+                    />
+                    <SpaceTitle>{space.title}</SpaceTitle>
+                  </ImageTitleWrapper>
+                  <Button bgColor="white" size="fixedS">
+                    <CancelButtonTitle>요청 취소</CancelButtonTitle>
+                  </Button>
+                </SpaceContentWrapper>
+              </SpaceListItem>
+            ))}
+          </SpaceList>
+        </WaitingSpaceWrapper>
+      </StyledPopoverContent>
+    </Popover>
+  );
+};
+
+const StyledPopoverContent = styled(PopoverContent)`
+  ${tw`bg-white px-4 py-5`}
+`;
+const WaitingSpaceWrapper = tw.div`flex flex-col gap-4`;
+const WaitingSpaceListHeader = tw.div`flex items-center justify-between`;
+const WaitingSpaceListTitle = tw.span`text-B16`;
+const WaitingSpaceDropdownButton = tw.button`relative flex h-10 w-10 items-center justify-center rounded-md border border-line p-2 md:(h-8 w-8)`;
+const WaitingSpaceCountWrapper = tw.div`absolute left-7 flex h-5 w-5 items-center justify-center rounded-full border border-line bg-white p-1 top-[-10px] md:(left-5 h-4 w-4 top-[-8px])`;
+const WaitingSpaceCount = tw.span`text-B12 text-red md:text-M10`;
+
+const SpaceList = tw.ul`flex w-full flex-col items-start gap-4 md:gap-2`;
+const SpaceListItem = tw.li`flex h-8 w-full items-center justify-between`;
+const SpaceContentWrapper = tw.div`flex w-full justify-between`;
+const ImageTitleWrapper = tw.div`flex items-center gap-2`;
+const SpaceImage = tw.img`h-8 w-8 md:(h-6 w-6)`;
+const SpaceTitle = tw.span`text-M14 text-text md:text-M12`;
+
+const CancelButtonTitle = tw.span`text-M14 md:text-M12`;

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+
+import { cn } from '@/lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/src/hooks/queries/use-get-waiting-space-list.ts
+++ b/src/hooks/queries/use-get-waiting-space-list.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { getWaitingSpaceList } from '@/service/api/get-waiting-space-list';
+
+export const useGetWaitingSpaceList = () => {
+  return useQuery({
+    queryKey: ['waitingSpaceList'],
+    queryFn: () => getWaitingSpaceList(),
+  });
+};

--- a/src/hooks/use-element-width.ts
+++ b/src/hooks/use-element-width.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect, useRef } from 'react';
+
+export const useElementWidth = <T extends HTMLElement>(isActive?: boolean) => {
+  const elementRef = useRef<T>(null);
+  const [width, setWidth] = useState<number>(0);
+
+  useEffect(() => {
+    if (!elementRef.current) return;
+
+    setWidth(elementRef.current.clientWidth);
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.contentRect) {
+          setWidth(entry.contentRect.width);
+        }
+      }
+    });
+
+    observer.observe(elementRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isActive]);
+
+  return { elementRef, width };
+};

--- a/src/mocks/db/Spaces.ts
+++ b/src/mocks/db/Spaces.ts
@@ -5,6 +5,7 @@ const Spaces = [
     description: '건강한 생활을 위한 운동 모임입니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 2,
@@ -12,6 +13,7 @@ const Spaces = [
     description: '책을 읽고 함께 토론하는 모임입니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 3,
@@ -19,6 +21,7 @@ const Spaces = [
     description: '프로그래밍에 대해 배우고 연습합니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 4,
@@ -26,6 +29,7 @@ const Spaces = [
     description: '요리를 배우며 함께 요리하는 모임',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 5,
@@ -33,6 +37,7 @@ const Spaces = [
     description: '함께 산책하며 대화를 나누는 모임',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 6,
@@ -40,6 +45,7 @@ const Spaces = [
     description: '그림을 그리며 창의력을 발휘해봅니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 7,
@@ -47,6 +53,7 @@ const Spaces = [
     description: '악기 연습을 함께 하는 모임.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 8,
@@ -54,6 +61,7 @@ const Spaces = [
     description: '외국어를 배우고 연습하는 모임',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 9,
@@ -61,6 +69,7 @@ const Spaces = [
     description: '명상으로 마음의 평화를 찾습니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 10,
@@ -68,6 +77,7 @@ const Spaces = [
     description: '글을 쓰며 생각을 정리해보는 모임',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 11,
@@ -75,6 +85,7 @@ const Spaces = [
     description: '함께 춤을 추는 모임',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 12,
@@ -82,6 +93,7 @@ const Spaces = [
     description: '사진을 찍으며 순간을 기록합니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 13,
@@ -89,6 +101,7 @@ const Spaces = [
     description: '새로운 요리를 시도하며 즐깁니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 14,
@@ -96,6 +109,7 @@ const Spaces = [
     description: '영화를 보고 감상을 나눕니다.',
     currentPeople: 9,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 15,
@@ -103,6 +117,7 @@ const Spaces = [
     description: '좋은 음악을 함께 들어봅니다.',
     currentPeople: 10,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 16,
@@ -110,6 +125,7 @@ const Spaces = [
     description: '자전거를 타며 체력을 단련합니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 17,
@@ -117,6 +133,7 @@ const Spaces = [
     description: '주요 뉴스와 이슈에 대해 논의합니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 18,
@@ -124,6 +141,7 @@ const Spaces = [
     description: '수공예를 통해 작품을 만듭니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 19,
@@ -131,6 +149,7 @@ const Spaces = [
     description: '새로운 기술을 배우며 개발합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 20,
@@ -138,6 +157,7 @@ const Spaces = [
     description: '청소를 통해 쾌적한 공간을 만듭니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 21,
@@ -145,6 +165,7 @@ const Spaces = [
     description: '매일 30분 이상 운동합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 22,
@@ -152,6 +173,7 @@ const Spaces = [
     description: '매일 책을 읽고 생각을 나눕니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 23,
@@ -159,6 +181,7 @@ const Spaces = [
     description: '매일 코딩하며 실력을 높입니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 24,
@@ -166,6 +189,7 @@ const Spaces = [
     description: '매일 요리하는 모임입니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 25,
@@ -173,6 +197,7 @@ const Spaces = [
     description: '매일 산책하며 건강을 챙깁니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 26,
@@ -180,6 +205,7 @@ const Spaces = [
     description: '매일 그림을 그려보는 모임입니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 27,
@@ -187,6 +213,7 @@ const Spaces = [
     description: '악기 연습으로 실력을 향상합니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 28,
@@ -194,6 +221,7 @@ const Spaces = [
     description: '외국어를 매일 학습합니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 29,
@@ -201,6 +229,7 @@ const Spaces = [
     description: '명상을 통해 내적 평화를 찾습니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 30,
@@ -208,6 +237,7 @@ const Spaces = [
     description: '글쓰기를 통해 생각을 정리해봅니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 31,
@@ -215,6 +245,7 @@ const Spaces = [
     description: '함께 등산을 즐기는 모임입니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 32,
@@ -222,6 +253,7 @@ const Spaces = [
     description: '헬스와 운동을 함께 합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 33,
@@ -229,6 +261,7 @@ const Spaces = [
     description: '명화와 예술 작품을 감상합니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 34,
@@ -236,6 +269,7 @@ const Spaces = [
     description: '자연 속에서 캠핑을 즐깁니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 35,
@@ -243,6 +277,7 @@ const Spaces = [
     description: '도자기 공예를 배우는 모임입니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 36,
@@ -250,6 +285,7 @@ const Spaces = [
     description: '다양한 문화를 경험합니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 37,
@@ -257,6 +293,7 @@ const Spaces = [
     description: '사진을 편집하며 창의력을 키웁니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 38,
@@ -264,6 +301,7 @@ const Spaces = [
     description: '새로운 악기를 배우는 모임입니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 39,
@@ -271,6 +309,7 @@ const Spaces = [
     description: '자원 봉사 활동에 참여합니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 40,
@@ -278,6 +317,7 @@ const Spaces = [
     description: '책을 교환하며 지식을 나눕니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 41,
@@ -285,6 +325,7 @@ const Spaces = [
     description: '환경 보호를 위해 함께 활동합니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 42,
@@ -292,6 +333,7 @@ const Spaces = [
     description: '아침마다 운동을 합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 43,
@@ -299,6 +341,7 @@ const Spaces = [
     description: '영화를 보고 분석하는 모임입니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 44,
@@ -306,6 +349,7 @@ const Spaces = [
     description: '사회적 이슈에 대해 토론합니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 45,
@@ -313,6 +357,7 @@ const Spaces = [
     description: '창의력을 높이는 활동을 합니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 46,
@@ -320,6 +365,7 @@ const Spaces = [
     description: '자기계발을 목표로 함께합니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 47,
@@ -327,6 +373,7 @@ const Spaces = [
     description: '건강을 위한 습관을 실천합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 48,
@@ -334,6 +381,7 @@ const Spaces = [
     description: '스스로 학습하며 성장을 도모합니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 49,
@@ -341,6 +389,7 @@ const Spaces = [
     description: '새로운 사람들과 교류하는 모임입니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 50,
@@ -348,6 +397,7 @@ const Spaces = [
     description: '개발자들끼리 네트워킹을 도모합니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 51,
@@ -355,6 +405,7 @@ const Spaces = [
     description: '스트레스를 함께 해소해보아요.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 52,
@@ -362,6 +413,7 @@ const Spaces = [
     description: '올바른 생활 습관을 만듭니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 53,
@@ -369,6 +421,7 @@ const Spaces = [
     description: '하이킹으로 체력을 길러봅니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 54,
@@ -376,6 +429,7 @@ const Spaces = [
     description: '함께 코딩하며 협력합니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 55,
@@ -383,6 +437,7 @@ const Spaces = [
     description: '예술 작품을 탐방합니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 56,
@@ -390,6 +445,7 @@ const Spaces = [
     description: '다양한 음식을 탐방합니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 57,
@@ -397,6 +453,7 @@ const Spaces = [
     description: '자연 속을 탐험합니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 58,
@@ -404,6 +461,7 @@ const Spaces = [
     description: '책을 읽고 함께 공부합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 59,
@@ -411,6 +469,7 @@ const Spaces = [
     description: '함께 서핑을 즐깁니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 60,
@@ -418,6 +477,7 @@ const Spaces = [
     description: '삶을 계획하며 발전해봅니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 61,
@@ -425,6 +485,7 @@ const Spaces = [
     description: '건강한 식습관을 만듭니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 62,
@@ -432,6 +493,7 @@ const Spaces = [
     description: '멘토와 멘티가 함께 성장합니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 63,
@@ -439,6 +501,7 @@ const Spaces = [
     description: '다양한 취미를 시도해봅니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 64,
@@ -446,6 +509,7 @@ const Spaces = [
     description: '자연을 느끼며 산책합니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 65,
@@ -453,6 +517,7 @@ const Spaces = [
     description: '자기소개서를 작성합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 66,
@@ -460,6 +525,7 @@ const Spaces = [
     description: '공예를 통해 예술 감각을 키웁니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 67,
@@ -467,6 +533,7 @@ const Spaces = [
     description: '자유롭게 여행하며 경험을 쌓습니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 68,
@@ -474,6 +541,7 @@ const Spaces = [
     description: '매일 운동하며 건강을 유지합니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 69,
@@ -481,6 +549,7 @@ const Spaces = [
     description: '매일 운동하기를 실천합니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 70,
@@ -488,6 +557,7 @@ const Spaces = [
     description: '심리학을 함께 공부합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 71,
@@ -495,6 +565,7 @@ const Spaces = [
     description: '언어 회화를 연습합니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 72,
@@ -502,6 +573,7 @@ const Spaces = [
     description: '자취 생활을 위한 모임입니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 73,
@@ -509,6 +581,7 @@ const Spaces = [
     description: '취업 준비를 위한 모임입니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 74,
@@ -516,6 +589,7 @@ const Spaces = [
     description: '바다를 감상하며 힐링합니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 75,
@@ -523,6 +597,7 @@ const Spaces = [
     description: '혼자 여행하며 여유를 즐깁니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 76,
@@ -530,6 +605,7 @@ const Spaces = [
     description: '집에서 식물을 기릅니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 77,
@@ -537,6 +613,7 @@ const Spaces = [
     description: '마라톤에 도전하기 위한 모임입니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 78,
@@ -544,6 +621,7 @@ const Spaces = [
     description: '수영 실력을 키워보아요.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 79,
@@ -551,6 +629,7 @@ const Spaces = [
     description: '모바일 앱을 개발해봅니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 80,
@@ -558,6 +637,7 @@ const Spaces = [
     description: '자기계발서를 읽고 토론합니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 81,
@@ -565,6 +645,7 @@ const Spaces = [
     description: '플라잉 요가를 함께 합니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 82,
@@ -572,6 +653,7 @@ const Spaces = [
     description: '해외 뉴스를 시청합니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 83,
@@ -579,6 +661,7 @@ const Spaces = [
     description: '공예품을 직접 만들어봅니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 84,
@@ -586,6 +669,7 @@ const Spaces = [
     description: '아카펠라 연습 모임입니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 85,
@@ -593,6 +677,7 @@ const Spaces = [
     description: '꽃을 다듬으며 힐링합니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 86,
@@ -600,6 +685,7 @@ const Spaces = [
     description: '해외 제품을 함께 구매합니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 87,
@@ -607,6 +693,7 @@ const Spaces = [
     description: '어학 수업을 함께 수강합니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 88,
@@ -614,6 +701,7 @@ const Spaces = [
     description: '웃음을 나누는 코미디 모임입니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 89,
@@ -621,6 +709,7 @@ const Spaces = [
     description: '직접 가구를 제작합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 90,
@@ -628,6 +717,7 @@ const Spaces = [
     description: '함께 산행을 즐기는 모임입니다.',
     currentPeople: 6,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 91,
@@ -635,6 +725,7 @@ const Spaces = [
     description: '건강과 운동을 지향합니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 92,
@@ -642,6 +733,7 @@ const Spaces = [
     description: '스트레칭을 배우고 실천합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 93,
@@ -649,6 +741,7 @@ const Spaces = [
     description: '심리 상담을 공유합니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 94,
@@ -656,6 +749,7 @@ const Spaces = [
     description: '야구 경기를 함께 관람합니다.',
     currentPeople: 8,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 95,
@@ -663,6 +757,7 @@ const Spaces = [
     description: '손으로 만드는 공예 모임입니다.',
     currentPeople: 3,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 96,
@@ -670,6 +765,7 @@ const Spaces = [
     description: '핸드드립 커피를 배우는 모임입니다.',
     currentPeople: 2,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 97,
@@ -677,6 +773,7 @@ const Spaces = [
     description: '불꽃놀이를 함께 관람합니다.',
     currentPeople: 5,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 98,
@@ -684,6 +781,7 @@ const Spaces = [
     description: '혼자만의 시간을 위한 모임입니다.',
     currentPeople: 7,
     maxPeople: 10,
+    image: null,
   },
   {
     id: 99,
@@ -691,6 +789,7 @@ const Spaces = [
     description: '컬러링을 하며 스트레스를 풉니다.',
     currentPeople: 4,
     maxPeople: 10,
+    image: null,
   },
 ];
 

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
 import { getJoinedSpacesHandler } from '@/mocks/handlers/spaces/get-joined-spaces-handler';
+import { getWaitingSpacesHandler } from '@/mocks/handlers/spaces/get-waiting-spaces-handler';
 
-export const handlers = [getJoinedSpacesHandler];
+export const handlers = [getJoinedSpacesHandler, getWaitingSpacesHandler];

--- a/src/mocks/handlers/spaces/get-waiting-spaces-handler.ts
+++ b/src/mocks/handlers/spaces/get-waiting-spaces-handler.ts
@@ -1,0 +1,33 @@
+import { API_URL } from '@/constants/api';
+import { createError } from '@/mocks/db/Error';
+import { Spaces, WaitingSpaces } from '@/mocks/db/Spaces';
+import { getRandomBoolean } from '@/mocks/utils/random';
+import { http, HttpResponse } from 'msw';
+
+export const getWaitingSpacesHandler = http.get(
+  `${API_URL}/members/waiting`,
+  () => {
+    const userWaitingSpaces = Spaces.filter((space) =>
+      WaitingSpaces.some((waitingSpaceId) => waitingSpaceId === space.id)
+    ).map(({ id, title, image }) => ({
+      id,
+      title,
+      image,
+    }));
+
+    if (getRandomBoolean()) {
+      return HttpResponse.json(createError('알 수 없는 에러가 발생했습니다'), {
+        status: 500,
+      });
+    }
+
+    return HttpResponse.json(
+      {
+        data: {
+          teamOutlines: userWaitingSpaces,
+        },
+      },
+      { status: 200 }
+    );
+  }
+);

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -45,20 +45,6 @@ export const HomePage = () => {
           </HeaderM.Right>
         </HeaderM>
       )}
-      {!isMobile && <Header userCode={userCode!} userAppName={userAppName!} />}
-      {isMobile && (
-        <HeaderM>
-          <HeaderM.Left>
-            <img src={Logo} alt="do-with 로고" />
-          </HeaderM.Left>
-          <HeaderM.Center>
-            <HeaderTitle>dowith</HeaderTitle>
-          </HeaderM.Center>
-          <HeaderM.Right>
-            <Avatar name={userCode!} variant="beam" size={40} />
-          </HeaderM.Right>
-        </HeaderM>
-      )}
       <ContentWrapper>
         <JoinedSpaceSection>
           <JoinedSpaceSectionHeader>

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,4 +1,3 @@
-import FileIcon from '@/assets/icons/file.svg?react';
 import HomeIcon from '@/assets/icons/home.svg?react';
 import PlusIcon from '@/assets/icons/plus.svg?react';
 import { Tooltip } from '@/components/common/tooltip/tooltip';
@@ -15,15 +14,18 @@ import { useMediaQuery } from '@/hooks/use-media-query';
 import { MOBILE_MEDIAQUERY } from '@/constants/media-query';
 import { useAuthCheckAndRedirectLogin } from '@/hooks/use-auth-check-and-redirect-login';
 import { SearchedSpaceList } from '@/components/space-list/searched-space-list';
+import { WaitingSpaceList } from '@/components/space-list/waiting-space-list';
 import { openModal } from '@/store/use-modal-store';
+import { useElementWidth } from '@/hooks/use-element-width';
 
 export const HomePage = () => {
   const userCode = useUserCode();
   const userAppName = useUserAppName();
   const { data: joinedSpaceList = [] } = useGetJoinedSpaceList();
   const isMobile = useMediaQuery(MOBILE_MEDIAQUERY);
-
   const isCheckingAuth = useAuthCheckAndRedirectLogin();
+  const { elementRef: joinedSpaceSectionRef, width: joinedSpaceSectionWidth } =
+    useElementWidth<HTMLDivElement>(isCheckingAuth);
 
   if (isCheckingAuth) {
     return <></>;
@@ -46,7 +48,7 @@ export const HomePage = () => {
         </HeaderM>
       )}
       <ContentWrapper>
-        <JoinedSpaceSection>
+        <JoinedSpaceSection ref={joinedSpaceSectionRef}>
           <JoinedSpaceSectionHeader>
             <TitleAndWaitButtonWrapper>
               <JoinedSpaceTitleWrapper>
@@ -56,13 +58,7 @@ export const HomePage = () => {
                   {joinedSpaceList.length} / {MAX_SPACES_PER_USER}
                 </JoinedSpaceCount>
               </JoinedSpaceTitleWrapper>
-              <WaitingSpaceDropdownButton>
-                <FileIcon className="size-7 md:size-6" />
-                <WaitingSpaceCountWrapper>
-                  {/* 참여 대기중 목록의 길이(개수) 표시 */}
-                  <WaitingSpaceCount>1</WaitingSpaceCount>
-                </WaitingSpaceCountWrapper>
-              </WaitingSpaceDropdownButton>
+              <WaitingSpaceList containerWidth={joinedSpaceSectionWidth} />
             </TitleAndWaitButtonWrapper>
             {joinedSpaceList.length > 0 && (
               <JoinedSpaceDescription>
@@ -107,11 +103,7 @@ const TitleAndWaitButtonWrapper = tw.div`flex w-full items-center justify-betwee
 const JoinedSpaceTitleWrapper = tw.div`flex items-center gap-2`;
 const JoinedSpaceTitle = tw.span`pt-1 text-B20 text-title md:text-B16`;
 const JoinedSpaceCount = tw.span`pt-1`;
-const WaitingSpaceDropdownButton = tw.button`relative flex h-10 w-10 items-center justify-center rounded-md border border-line p-2 md:(h-8 w-8)`;
-const WaitingSpaceCountWrapper = tw.div`absolute left-7 flex h-5 w-5 items-center justify-center rounded-full border border-line bg-white p-1 top-[-10px] md:(left-5 h-4 w-4 top-[-8px])`;
-const WaitingSpaceCount = tw.span`text-B12 text-red md:text-M10`;
 const JoinedSpaceDescription = tw.span`inline-block truncate text-M14 text-textWeak md:text-M10`;
 
 const SearchedSpaceSection = tw.div`flex grow flex-col items-start justify-between overflow-y-auto lg:h-[calc(100vh - 72px)] xl:h-[calc(100vh - 72px)]`;
-
 const TooltipWrapper = tw.div`fixed bottom-5 right-4 flex w-full items-center justify-end gap-2`;

--- a/src/service/api/get-waiting-space-list.ts
+++ b/src/service/api/get-waiting-space-list.ts
@@ -1,0 +1,12 @@
+import { privateApi } from '../axios';
+
+export const getWaitingSpaceList = async (): Promise<TWaitingSpaceData[]> => {
+  try {
+    const response =
+      await privateApi.get<TWaitingSpaceResponseData>('/members/waiting');
+
+    return response.data.data.teamOutlines;
+  } catch (error) {
+    throw new Error('가입 대기 스페이스 목록을 불러오는데 실패하였습니다.');
+  }
+};

--- a/src/types/space-list.d.ts
+++ b/src/types/space-list.d.ts
@@ -40,3 +40,15 @@ type TRandomSpaceResponseData = {
     randomTeamOutlines: Array<TRandomSpaceData>;
   };
 };
+
+type TWaitingSpaceData = {
+  id: number;
+  title: string;
+  image: string | null;
+};
+
+type TWaitingSpaceResponseData = {
+  data: {
+    teamOutlines: Array<TWaitingSpaceData>;
+  };
+};


### PR DESCRIPTION
## Key changes 📝
<!--이 섹션에는 PR에 포함된 주요 변경사항을 상세하게 기술해주세요.-->

- 가입 대기 스페이스 UI 구현

<!--
[예시]
사용자 프로필 사진을 원형에서 사각형으로 변경
프로필 정보 섹션의 배경색을 연한 회색에서 흰색으로 업데이트
"프로필 편집" 버튼 스타일 및 위치 수정
사용자의 게시물 표시 방식을 그리드 레이아웃에서 리스트 레이아웃으로 변경 -->

## To reviewers 👋
<!--이 섹션에는 코드 리뷰어들을 위한 메시지나 안내사항을 기록해주세요.-->

- 가입 대기 스페이스는 shadcn의 popover를 사용하여 구현하였는데, 가입중인 스페이스의 width와 동일한 width로 스타일링하기 위해 useElementWidth 훅 작성 및 사용하였습니다.

<!--
[예시]
이번 PR에서는 사용자 프로필 페이지의 디자인을 주요하게 변경하였습니다. 특히, 게시물 표시 방식에 관한 변경은 사용자 경험에 큰 영향을 미칠 수 있으니, 이 부분에 대한 피드백을 중점적으로 부탁드립니다. 또한, 다른 부분에 대한 의견도 자유롭게 공유해주세요. -->
